### PR TITLE
Optimized Outdated Statistics Warning WHERE clause and resolved needing two UPDATE statements for Partitioned table stats

### DIFF
--- a/checks/check_indexes.sql
+++ b/checks/check_indexes.sql
@@ -223,9 +223,7 @@ BEGIN
 			|| '. last_autoanalyze on ' || COALESCE(i.last_autoanalyze::date::varchar, '(never)') AS warning_details,
 	'https://smartpostgres.com/problems/outdated_statistics' AS url
 	FROM ci_indexes i
-	WHERE (i.estimated_tuples_from_pg_class_reltuples + i.n_ins_since_vacuum + i.n_mod_since_analyze) > 1000
-		AND (ABS(1 - (i.estimated_tuples_from_pg_class_reltuples::numeric / (i.estimated_tuples_from_pg_class_reltuples::numeric + i.n_ins_since_vacuum::numeric + 1))) > 0.1
-       			OR ABS(1 - (i.estimated_tuples_from_pg_class_reltuples::numeric / (i.estimated_tuples_from_pg_class_reltuples::numeric + i.n_mod_since_analyze::numeric + 1))) > 0.1);
+    WHERE ABS(i.estimated_tuples_from_pg_class_reltuples::numeric) * 0.1 < GREATEST(i.n_ins_since_vacuum, i.n_mod_since_analyze);
 
 
     -- Return the result set


### PR DESCRIPTION
Changed the calculation of the Outdated Statistics WHERE clause from a multi-part calculation, including division, into a single line using multiplication that will better handle small tables and does not require manipulation to ensure there is no division by 0.

Changed the Update Partitioned Index statement to resolve the update in a single statement instead of requiring two updates.