### PR TITLE
Partitioned Table Fix Estimated Tuple Count On Base Table

### DIFF
--- a/checks/check_indexes.sql
+++ b/checks/check_indexes.sql
@@ -184,7 +184,7 @@ BEGIN
 			                                                THEN child.reltuples
 			                                                ELSE tbl.estimated_tuples_from_pg_class_reltuples END
 	FROM (SELECT inh.inhparent, SUM(pg_relation_size(child.oid) / 1024.0) AS size_kb,
-			SUM(COALESCE(child.reltuples, 0)) AS reltuples
+			SUM(GREATEST(COALESCE(child.reltuples, 0), 0)) AS reltuples
 		FROM pg_catalog.pg_inherits inh 
 		JOIN pg_catalog.pg_class child ON inh.inhrelid = child.oid
 		GROUP BY inh.inhparent


### PR DESCRIPTION
As mentioned in your recent live stream, due to the -1 estimated tuple count on base tables, the rolled up partitioned table values contains a different count relative to the indexes which all begin with an estimated count of 0. You proposed fixing it and then went on without addressing it and I didn't want this to get lost.