### PR TITLE
Fix last_vacuum column removed in error from Child Partitioned Tables Insert

### DIFF
--- a/checks/check_indexes.sql
+++ b/checks/check_indexes.sql
@@ -150,7 +150,7 @@ BEGIN
     sql_to_execute := '
     INSERT INTO ci_indexes (schema_name, table_name, index_name, index_type, index_definition, size_kb, estimated_tuples, estimated_tuples_as_of, 
 		is_unique, is_primary, table_oid, index_oid, relkind, reltoastrelid, 
-		n_mod_since_analyze, n_ins_since_vacuum, last_autovacuum, last_analyze, last_autoanalyze)
+		n_mod_since_analyze, n_ins_since_vacuum, last_manual_nonfull_vacuum, last_autovacuum, last_analyze, last_autoanalyze)
     SELECT
         nm.nspname AS schema_name,
         c_tbl.relname AS table_name,
@@ -176,7 +176,7 @@ BEGIN
         CAST(NULL AS INTEGER) AS index_oid,
 		c_tbl.relkind,
         c_tbl.reltoastrelid,
-		stat.n_mod_since_analyze, stat.n_ins_since_vacuum, stat.last_autovacuum, stat.last_analyze, stat.last_autoanalyze
+		stat.n_mod_since_analyze, stat.n_ins_since_vacuum, stat.last_vacuum, stat.last_autovacuum, stat.last_analyze, stat.last_autoanalyze
     FROM pg_catalog.pg_inherits inh 
     JOIN pg_catalog.pg_class c_tbl ON inh.inhrelid = c_tbl.oid
     JOIN pg_catalog.pg_namespace nm ON


### PR DESCRIPTION
During the merge, there was a fix to the error of the bad column name last_vacuum; the problem was you renamed it last_manual_nonfull_vacuum instead of last_vacuum, to be more precise. I have added the column back into the child-partitioned tables so you can see the effect. To test, run a manual vacuum on an underlying partition table such as:

    vacuum users_partitioned_2020;
Before this fix is in place, the last_manual_nonfull_vacuum column will continue to show null. After the fix, that column should show the timestamp appropriately.