### PR TITLE
#22 autovacuum not keeping up

### DIFF
--- a/checks/testing/create_bad_schema.sql
+++ b/checks/testing/create_bad_schema.sql
@@ -22,6 +22,28 @@ CREATE TABLE public.users (
     "ヅ" VARCHAR
 );
 
+-- Set the autovacuum settings
+alter table public.users set (autovacuum_enabled = false);
+
+ALTER TABLE public.users 
+    SET (autovacuum_vacuum_threshold = 500,  -- Minimum number of dead tuples before vacuuming starts
+         autovacuum_vacuum_scale_factor = 0.02,  -- Percentage of the table size that triggers a vacuum
+         autovacuum_analyze_threshold = 500,  -- Minimum number of tuple changes before analyze starts
+         autovacuum_analyze_scale_factor = 0.02,  -- Percentage of the table size that triggers an analyze
+         autovacuum_vacuum_cost_delay = 20,  -- Delay in milliseconds between vacuum operations
+         autovacuum_vacuum_cost_limit = 2000,  -- Cost limit for vacuuming before taking a delay
+         autovacuum_freeze_max_age = 200000000,  -- Maximum age of tuples before forcing a vacuum to prevent transaction wraparound
+         autovacuum_multixact_freeze_max_age = 400000000);  -- Maximum age of multixact before vacuum forces wraparound prevention
+
+-- Optionally, reset the settings back to the default values:
+-- ALTER TABLE sales RESET (autovacuum_enabled, autovacuum_vacuum_threshold, autovacuum_vacuum_scale_factor, 
+--                          autovacuum_analyze_threshold, autovacuum_analyze_scale_factor, autovacuum_vacuum_cost_delay, 
+--                          autovacuum_vacuum_cost_limit, autovacuum_freeze_max_age, autovacuum_multixact_freeze_max_age);
+
+         
+         
+         
+
 INSERT INTO public.users
 (display_name, email, reputation, creation_date, last_access_date, "location", about_me, about_me_tsvector, 
 website_url, profile_image_url, "space space", "1", " ", ".", ",", """", "ヅ")
@@ -68,6 +90,11 @@ website_url, profile_image_url, "space space", "1", " ", ".", ",", """", "ヅ")
 select 'John Malkovich', uuid_in(md5(random()::text || random()::text)::cstring), 1, '2024-08-20', '2024-08-20', 'Las Vegas, NV', 'A fictional character', 'A fictional character',
 	'https://SmartPostgres.com', null, 'space space', '1', ' ', '.', ',', '"', 'ヅ'
 from generate_series(1,10000);
+
+
+delete from public.users;
+
+
 
 
 drop view if exists public.vw_users;


### PR DESCRIPTION
Working on #22, but has 3 known issues in the code labeled BGO FIXFIX.

	/* BGO FIXFIX:
		This does not include a percentage threshold above for warning purposes,
			but just immediately fires if we are even 1 row above the autovacuum
			threshold, which is probably too noisy. We probably want to alert
			when we are say 10% over the threshold.

		This query is running by using pg_class.reloptions.
			I want it to run based on c_tbl.reloptions instead.

		I do not know that the estimated tuple threshold reporting is accurate
			from the formula written by ChatGPT.
	*/
